### PR TITLE
Use runtimecore's gitignore for cross platform build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,45 @@
-## Compiled source #
-*.com
-*.class
-*.dll
-*.exe
-*.o
-*.so
-test
+# Premake generated files #
+###########################
+*.vcxproj*
+*.sln
+Makefile
+*.make
+*.xcworkspace
+*.xcodeproj
+compile_commands.json
 
-## Logs and databases #
-*.log
-*.sql
-*.sqlite
-
-## OS generated files #
-.DS_Store
-.DS_Store?
+# OS generated files #
+######################
+.DS_Store*
 ._*
 .Spotlight-V100
 .Trashes
 ehthumbs.db
 Thumbs.db
+.project
 
-## Build dir
-Build/*
+# VS generated files #
+######################
+ipch/
+*.suo
+*.opensdf
+*.sdf
+*.vcxproj
+*.filters
+*.user
+*.cso
+.vscode
+*.code-workspace
 
-## xcode specific
-*xcuserdata*
+# Qt files #
+############
+*.config
+*.creator*
+*.files
+*.includes
+*.user*
+moc/
+
+# git noise #
+#############
+**/*.orig


### PR DESCRIPTION
@nmlapre-runtime here's just a minor update to ignore our build files.  