### PR TITLE
Check rotation orientation in all cases

### DIFF
--- a/Source/tess.c
+++ b/Source/tess.c
@@ -255,9 +255,7 @@ void tessProjectPolygon( TESStesselator *tess )
 		v->s = Dot( v->coords, sUnit );
 		v->t = Dot( v->coords, tUnit );
 	}
-	if( computedNormal ) {
-		CheckOrientation( tess );
-	}
+	CheckOrientation( tess );
 
 	/* Compute ST bounds. */
 	first = 1;


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtimecore/map_renderer_3d/issues/4248

Right now the rotation orientation is only computed when no normal vector is passed in to libtess. This works for us right now
because we don't pass in a vector. 

In order to address the linked issue we want to pass in a normal, and without the orientation being computed polygon fills are not rendered correctly.

3rdparty vTest: http://runtime-test.esri.com:8080/view/vTest/job/vtest-3rdparty_libraries-interface/469/downstreambuildview/
vTest: http://runtime-test.esri.com:8080/view/vTest/job/vtest-runtimecore-interface/7748/downstreambuildview/